### PR TITLE
[Feat] 사용자 프로필 이미지 업로드 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ out/
 .vscode/
 
 application-local.yml
+
+# GCS 서비스 키
+dotdot_gcs.json

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,11 @@ dependencies {
 
 	// Java 8 LocalDateTime 직렬화 지원을 위한 Jackson 모듈
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
+	// 이미지 업로드를 위한 google cloud storage 의존성 추가
+	implementation group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter', version: '1.2.5.RELEASE'
+	implementation group: 'org.springframework.cloud', name: 'spring-cloud-gcp-storage', version: '1.2.5.RELEASE'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/example/dotdot/config/GoogleCloudStorageConfig.java
+++ b/src/main/java/com/example/dotdot/config/GoogleCloudStorageConfig.java
@@ -1,0 +1,26 @@
+package com.example.dotdot.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+
+@Configuration
+public class GoogleCloudStorageConfig {
+    @Bean
+    public Storage storage() throws IOException {
+
+        ClassPathResource resource = new ClassPathResource("dotdot_gcs.json");
+        GoogleCredentials credentials = GoogleCredentials.fromStream(resource.getInputStream());
+        String projectId = "dotdot-prod";
+        return StorageOptions.newBuilder()
+                .setProjectId(projectId)
+                .setCredentials(credentials)
+                .build()
+                .getService();
+    }
+}

--- a/src/main/java/com/example/dotdot/controller/UserController.java
+++ b/src/main/java/com/example/dotdot/controller/UserController.java
@@ -9,9 +9,11 @@ import com.example.dotdot.service.UserService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("api/v1/users")
@@ -40,13 +42,13 @@ public class UserController implements UserControllerSpecification{
 
 
 
-    @PutMapping("/me/profile-image")
-    public ResponseEntity<DataResponse<UserInfoResponse>> updateProfileImage(
+    @PutMapping(value = "/me/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<DataResponse<String>> updateProfileImage(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestParam("image") String image) {
+            @RequestPart("file") MultipartFile file) {
         Long userId = userDetails.getId();
-        UserInfoResponse updatedUserInfo = userService.updateProfileImage(userId, image);
-        return ResponseEntity.ok(DataResponse.from(updatedUserInfo));
+        String imageUrl = userService.updateProfileImage(userId, file);
+        return ResponseEntity.ok(DataResponse.from(imageUrl));
     }
 
 

--- a/src/main/java/com/example/dotdot/controller/UserControllerSpecification.java
+++ b/src/main/java/com/example/dotdot/controller/UserControllerSpecification.java
@@ -14,12 +14,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "UserController", description = "User 관련 API")
 public interface UserControllerSpecification {
@@ -64,12 +63,14 @@ public interface UserControllerSpecification {
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자 (USER-006)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 회원 (USER-001)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "이미지 업로드에 실패했습니다. (IMAGE-001)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    @PutMapping("/me/profile-image")
-    public ResponseEntity<DataResponse<UserInfoResponse>> updateProfileImage(
+    @PutMapping(value = "/me/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<DataResponse<String>> updateProfileImage(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestParam("image") String image);
+            @RequestPart("file") MultipartFile file);
 
 
 

--- a/src/main/java/com/example/dotdot/dto/request/user/SignupRequest.java
+++ b/src/main/java/com/example/dotdot/dto/request/user/SignupRequest.java
@@ -35,7 +35,7 @@ public class SignupRequest {
                 .email(email)
                 .password(password)
                 .name(name)
-                .profileImageUrl("https://example.com/default-profile.png") // 일단 기본 프로필 이미지 URL 설정
+                .profileImageUrl("basic") // 프로필 이미지 설정 안 했을 경우
                 .position(position)
                 .password(password)
                 .build();

--- a/src/main/java/com/example/dotdot/global/exception/user/ImageUploadFailException.java
+++ b/src/main/java/com/example/dotdot/global/exception/user/ImageUploadFailException.java
@@ -1,0 +1,10 @@
+package com.example.dotdot.global.exception.user;
+
+import com.example.dotdot.global.exception.AppException;
+import com.example.dotdot.global.exception.ErrorCode;
+
+public class ImageUploadFailException extends AppException {
+    public ImageUploadFailException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/dotdot/global/exception/user/UserErrorCode.java
+++ b/src/main/java/com/example/dotdot/global/exception/user/UserErrorCode.java
@@ -15,7 +15,8 @@ public enum UserErrorCode implements ErrorCode {
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다.", "USER-003"),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 잘못되었습니다.", "USER-004"),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다.", "USER-005"),
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다. 토큰이 없거나 유효하지 않습니다.","USER-006" );
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다. 토큰이 없거나 유효하지 않습니다.","USER-006" ),
+    IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패했습니다.", "IMAGE-001")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -11,6 +11,14 @@ spring:
       hibernate:
         format_sql: true
 
+  cloud:
+    gcp:
+      storage:
+        credentials:
+          location: classpath:dotdot_gcs.json
+        project-id: dotdot-prod
+        bucket: dotdot-bucket
+
 security:
   jwt:
     token:


### PR DESCRIPTION
## #️⃣ Issue Number

Closes #3

## 📝 요약(Summary)
- 사용자 프로필 이미지 업로드 기능 구현
- GCS를 연동하여 이미지 업로드
- Swagger 문서화 설정

## 🛠️ PR 유형
- [x] 새로운 기능 추가
- [x] 문서 수정
- [x] 빌드 부분 혹은 패키지 매니저 수정

## 📸스크린샷 (선택)
<img width="768" alt="스크린샷 2025-07-06 오후 3 42 59" src="https://github.com/user-attachments/assets/fc5df7f7-5b84-49e5-bd16-9786279fbed5" />

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->