### PR TITLE
feat : 회의 삭제 구현

### DIFF
--- a/src/main/java/com/example/dotdot/controller/MeetingController.java
+++ b/src/main/java/com/example/dotdot/controller/MeetingController.java
@@ -150,4 +150,12 @@ public class MeetingController implements MeetingControllerSpecification{
         }
     }
 
+    @DeleteMapping("/{meetingId}")
+    public ResponseEntity<DataResponse<Void>> deleteMeeting(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long meetingId) {
+        meetingService.deleteMeeting(userDetails.getId(), meetingId);
+        return ResponseEntity.ok(DataResponse.ok());
+    }
+
 }

--- a/src/main/java/com/example/dotdot/controller/MeetingControllerSpecification.java
+++ b/src/main/java/com/example/dotdot/controller/MeetingControllerSpecification.java
@@ -181,4 +181,23 @@ public interface MeetingControllerSpecification {
             @RequestBody @Valid MeetingStatusUpdateRequest req
     );
 
+    @Operation(summary = "회의 삭제", description = "회의를 삭제합니다.")
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회의 삭제 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자 (USER-006)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 회원 (USER-001)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 회의 (MEETING-001)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "회의 삭제 권한 없음 (MEETING-003)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @DeleteMapping("/{meetingId}")
+    ResponseEntity<DataResponse<Void>> deleteMeeting(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long meetingId
+    );
+
 }

--- a/src/main/java/com/example/dotdot/global/exception/meeting/MeetingErrorCode.java
+++ b/src/main/java/com/example/dotdot/global/exception/meeting/MeetingErrorCode.java
@@ -9,7 +9,10 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum MeetingErrorCode implements ErrorCode {
     MEETING_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회의를 찾을 수 없습니다.", "MEETING-001"),
-    MEETING_NOT_IN_TEAM(HttpStatus.FORBIDDEN,"해당 팀에 속한 회의가 없습니다","MEETING-002");
+    MEETING_NOT_IN_TEAM(HttpStatus.FORBIDDEN,"해당 팀에 속한 회의가 없습니다","MEETING-002"),
+    MEETING_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "회의를 삭제할 권한이 없습니다.", "MEETING-003");
+
+
     private final HttpStatus httpStatus;
     private final String message;
     private final String code;

--- a/src/main/java/com/example/dotdot/repository/RecommendationRepository.java
+++ b/src/main/java/com/example/dotdot/repository/RecommendationRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 
 public interface RecommendationRepository extends JpaRepository<Recommendation,Long> {
     List<Recommendation> findAllByMeetingOrderByPriorityAsc(Meeting meeting);
+
+    void deleteAllByMeetingId(Long meetingId);
 }

--- a/src/main/java/com/example/dotdot/repository/SpeechLogRepository.java
+++ b/src/main/java/com/example/dotdot/repository/SpeechLogRepository.java
@@ -14,4 +14,6 @@ public interface SpeechLogRepository extends JpaRepository<SpeechLog, Long> {
 
     // meeting 객체를 인자로 받아 조회
     List<SpeechLog> findByMeeting(Meeting meeting);
+
+    void deleteAllByMeetingId(Long meetingId);
 }

--- a/src/main/java/com/example/dotdot/repository/TaskRepository.java
+++ b/src/main/java/com/example/dotdot/repository/TaskRepository.java
@@ -33,6 +33,8 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
             Pageable pageable
     );
 
+    void deleteAllByMeetingId(Long meetingId);
+
     //진행 상황 요약
     interface StatusCount {
         TaskStatus getStatus();


### PR DESCRIPTION
## #️⃣ Issue Number
close #41 

## 📝 요약(Summary)
- 회의 삭제 기능 구현
  : 팀에 해당하는 사람만 회의 삭제 가능, 회의와 관련된 안건, speechlog 등 함께 삭제

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->